### PR TITLE
Add support for Timer control on GPIO P05 for BLENano2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ target_sources(app PRIVATE src/lwm2m.c)
 target_sources(app PRIVATE src/light_control.c)
 target_sources_ifdef(CONFIG_APP_LIGHT_TYPE_WS2812 app PRIVATE src/light_control_ws2812.c)
 target_sources_ifdef(CONFIG_APP_LIGHT_TYPE_PWM app PRIVATE src/light_control_pwm.c)
+target_sources_ifdef(CONFIG_APP_ENABLE_TIMER_OBJ app PRIVATE src/timer_control.c)
 target_sources_ifdef(CONFIG_NET_L2_BT        app PRIVATE src/bluetooth.c)
 
 target_link_libraries_ifdef(CONFIG_MBEDTLS app PRIVATE mbedTLS)

--- a/Kconfig.app
+++ b/Kconfig.app
@@ -28,4 +28,12 @@ config APP_LIGHT_TYPE_WS2812
 
 endchoice # APP_LIGHT_TYPE
 
+config APP_ENABLE_TIMER_OBJ
+	bool "Adds GPIO timer functionality for auto-shutoff"
+	select GPIO
+	select LWM2M_IPSO_TIMER
+	help
+	  This option adds a IPSO Timer object tied to P05 which can be set
+	  to auto-reset after x second delay.
+
 rsource "Kconfig.app.pwm"

--- a/boards/nrf52_blenano2.overlay
+++ b/boards/nrf52_blenano2.overlay
@@ -15,3 +15,17 @@
 &uart0 {
 	rts-pin = <0x03>;
 };
+
+/ {
+	buttons {
+		compatible = "gpio-keys";
+		timer0: timer_0 {
+			gpios = <&gpio0 5 GPIO_PUD_PULL_UP>;
+			label = "GPIO timer switch";
+		};
+	};
+
+	aliases {
+		dt-sw-timer0 = &timer0;
+	};
+};

--- a/overlay-timer.conf
+++ b/overlay-timer.conf
@@ -1,0 +1,2 @@
+# Turn on IPSO Timer support
+CONFIG_APP_ENABLE_TIMER_OBJ=y

--- a/src/main.c
+++ b/src/main.c
@@ -22,6 +22,9 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include "product_id.h"
 #include "lwm2m.h"
 #include "light_control.h"
+#if defined(CONFIG_APP_ENABLE_TIMER_OBJ)
+#include "timer_control.h"
+#endif
 
 /* Defines and configs for the IPSO elements */
 #define TEMP_DEV		"fota-temp"
@@ -120,6 +123,17 @@ void main(void)
 	}
 	_TC_END_RESULT(TC_PASS, "init_light_control");
 	TC_END_REPORT(TC_PASS);
+
+#if defined(CONFIG_APP_ENABLE_TIMER_OBJ)
+	TC_PRINT("Initializing IPSO Timer Control\n");
+	if (init_timer_control()) {
+		_TC_END_RESULT(TC_FAIL, "init_timer_control");
+		TC_END_REPORT(TC_FAIL);
+		return;
+	}
+	_TC_END_RESULT(TC_PASS, "init_timer_control");
+	TC_END_REPORT(TC_PASS);
+#endif /* CONFIG_ENABLE_TIMER_OBJ */
 
 	if (lwm2m_init(app_work_q)) {
 		return;

--- a/src/timer_control.c
+++ b/src/timer_control.c
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2019 Foundries.io
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define LOG_MODULE_NAME fota_timer
+#define LOG_LEVEL CONFIG_FOTA_LOG_LEVEL
+
+#include <logging/log.h>
+LOG_MODULE_REGISTER(LOG_MODULE_NAME);
+
+#include <zephyr.h>
+#include <gpio.h>
+#include <net/lwm2m.h>
+
+static void set_timer_gpio(bool state)
+{
+	struct device *gpio;
+
+	gpio = device_get_binding(DT_SW_TIMER0_GPIO_CONTROLLER);
+	if (!gpio) {
+		LOG_ERR("GPIO device not found; you must configure the GPIO\n"
+			"for the timer to activate in DTS.  See dt-sw-timer0\n"
+			"in boards/nrf52_blenano2.overlay");
+		return;
+	}
+
+	LOG_DBG("STATE:%d", state);
+	gpio_pin_configure(gpio, DT_SW_TIMER0_GPIO_PIN,
+			   DT_SW_TIMER0_GPIO_FLAGS);
+	gpio_pin_write(gpio, DT_SW_TIMER0_GPIO_PIN, state);
+}
+
+static int timer_digital_state_post_write_cb(u16_t obj_inst_id,
+					     u8_t *data, u16_t data_len,
+					     bool last_block, size_t total_size)
+{
+	bool *digital_state = (bool *)data;
+
+	/* adjust GPIO based on check the state */
+	if (*digital_state) {
+		set_timer_gpio(true);
+	} else {
+		set_timer_gpio(false);
+	}
+
+	return 0;
+}
+
+int init_timer_control(void)
+{
+	int ret;
+
+	/* Only one instance (ID 0) is supported. */
+	ret = lwm2m_engine_create_obj_inst("3340/0");
+	if (ret < 0) {
+		goto fail;
+	}
+
+	/* register for timer output state changes */
+	ret = lwm2m_engine_register_post_write_callback("3340/0/5543",
+			timer_digital_state_post_write_cb);
+	if (ret < 0) {
+		goto fail;
+	}
+
+	/* set application type */
+	ret = lwm2m_engine_set_string("3340/0/5750", DT_SW_TIMER0_LABEL);
+	if (ret < 0) {
+		goto fail;
+	}
+
+	return 0;
+
+fail:
+	return ret;
+}

--- a/src/timer_control.h
+++ b/src/timer_control.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2019 Open Source Foundries
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef FOTA_TIMER_CONTROL_H__
+#define FOTA_TIMER_CONTROL_H__
+
+int init_timer_control(void);
+
+#endif	/* FOTA_TIMER_CONTROL_H__ */


### PR DESCRIPTION
Now that Zephyr supports IPSO Timer object, let's use it on
GPIO P05 (set via DTS in boards/nrf52_blenano2.overlay)
to support Candy Machine / Drink Dispenser.

Signed-off-by: Michael Scott <mike@foundries.io>