### PR TITLE
dm-lwm2m-light fixes

### DIFF
--- a/boards/nrf52_blenano2.overlay
+++ b/boards/nrf52_blenano2.overlay
@@ -22,7 +22,7 @@
 	buttons {
 		compatible = "gpio-keys";
 		timer0: timer_0 {
-			gpios = <&gpio0 5 GPIO_PUD_PULL_UP>;
+			gpios = <&gpio0 5 GPIO_DIR_OUT>;
 			label = "GPIO timer switch";
 		};
 	};

--- a/boards/nrf52_blenano2.overlay
+++ b/boards/nrf52_blenano2.overlay
@@ -14,6 +14,10 @@
 	};
 };
 
+&pwm0 {
+	status = "ok";
+};
+
 &uart0 {
 	rts-pin = <0x03>;
 };

--- a/overlay-nrf52_blenano2-pwm.conf
+++ b/overlay-nrf52_blenano2-pwm.conf
@@ -1,5 +1,6 @@
 # Turn on PWM support
 CONFIG_APP_LIGHT_TYPE_PWM=y
+CONFIG_PWM_0=y
 
 # PWM settings (when enabled)
 CONFIG_PWM_NRF5_SW_0_DEV_NAME="PWM_0"

--- a/src/timer_control.c
+++ b/src/timer_control.c
@@ -50,6 +50,7 @@ static int timer_digital_state_post_write_cb(u16_t obj_inst_id,
 
 int init_timer_control(void)
 {
+	float64_value_t delay_duration;
 	int ret;
 
 	/* Only one instance (ID 0) is supported. */
@@ -61,6 +62,14 @@ int init_timer_control(void)
 	/* register for timer output state changes */
 	ret = lwm2m_engine_register_post_write_callback("3340/0/5543",
 			timer_digital_state_post_write_cb);
+	if (ret < 0) {
+		goto fail;
+	}
+
+	/* set initial delay duration: .5 second */
+	delay_duration.val1 = 0LL;
+	delay_duration.val2 = 500000000LL;
+	ret = lwm2m_engine_set_float64("3340/0/5521", &delay_duration);
 	if (ret < 0) {
 		goto fail;
 	}


### PR DESCRIPTION
- Fix compile for PWM
- Set default timer duration to 0.5 second
- Set nr52_blenano P05 to output pin correctly